### PR TITLE
Improved data transmission robustness by assigning a new data id to each data value sent by emitter.Ack data

### DIFF
--- a/lib/LoRaPrivate/LoRaCfg.h
+++ b/lib/LoRaPrivate/LoRaCfg.h
@@ -9,18 +9,19 @@
 #define RST         14
 #define DIO0        26
 
-#define FREQ        868E6           //Signal frequency
-#define SPR_FACT    7               //Spreading factor
-#define BANDWIDTH   250E3           //Bandwidth
-//#define SYNC_WORD 0x00            //Syncronization byte
-//#define PREAM_LEN 8               //Signal preamble length
+#define FREQ        868E6                           //Signal frequency
+#define SPR_FACT    7                               //Spreading factor
+#define BANDWIDTH   250E3                           //Bandwidth
+//#define SYNC_WORD 0x00                            //Syncronization byte
+//#define PREAM_LEN 8                               //Signal preamble length
 
 #define OUT_BUFFER_SIZE     4       //Bytes per packet that will be sent
+#define EMITTER_ID          0x00                    //ID for each emitter
 
-#define EMITTER_ID          0x00    //ID for each emitter
+#define GATEWAY_ID          0x53AC                  //ID that all emmiters must use to communicate with gateway
+#define GATEWAY_ID_LEN      2U                      //Number of bytes that compose the gateway ID
 
-#define GATEWAY_ID          0x53AC  //ID that all emmiters must use to communicate with gateway
-#define GATEWAY_ID_LEN      2       //Number of bytes that compose the gateway ID
+#define OUT_BUFFER_SIZE     GATEWAY_ID_LEN + 3U     //Bytes per packet that will be sent
 
 #define ACK_TIMEOUT         5000U   //Acknowledgment timeout (ms)
 

--- a/lib/LoRaPrivate/LoRaCfg.h
+++ b/lib/LoRaPrivate/LoRaCfg.h
@@ -15,7 +15,6 @@
 //#define SYNC_WORD 0x00                            //Syncronization byte
 //#define PREAM_LEN 8                               //Signal preamble length
 
-#define OUT_BUFFER_SIZE     4       //Bytes per packet that will be sent
 #define EMITTER_ID          0x00                    //ID for each emitter
 
 #define GATEWAY_ID          0x53AC                  //ID that all emmiters must use to communicate with gateway

--- a/lib/LoRaPrivate/LoRaPrivate.cpp
+++ b/lib/LoRaPrivate/LoRaPrivate.cpp
@@ -6,7 +6,7 @@
 #include <LoRa.h>
 #include <customUtilities.h>
 
-RTC_DATA_ATTR uint8 out_packet [OUT_BUFFER_SIZE] = {(GATEWAY_ID & 0xFF00) >> 8, GATEWAY_ID & 0x00FF, EMITTER_ID, 0};
+RTC_DATA_ATTR uint8 out_packet [OUT_BUFFER_SIZE] = {(GATEWAY_ID & 0xFF00) >> 8, GATEWAY_ID & 0x00FF, EMITTER_ID, 69, 0}; //Final items: data id, data
 
 volatile bool Cad_isr_responded = false;
 volatile bool channel_busy = true;

--- a/lib/LoRaPrivate/LoRaPrivate.cpp
+++ b/lib/LoRaPrivate/LoRaPrivate.cpp
@@ -67,6 +67,22 @@ void onCadDone(bool signalDetected) //true menas signal is detected
   Cad_isr_responded = true;
 }
 
+//Prepares the packet with the data to send next. Returns 0 if successful, 1 if error.
+uint8 prepareNextPacket(void)
+{
+  //establish a new random data ID
+  uint8 old_data_id = out_packet[GATEWAY_ID_LEN + 1U];
+  do
+  {
+    out_packet[GATEWAY_ID_LEN + 1U] = (uint8)random(0xFF);
+  }while(out_packet[GATEWAY_ID_LEN + 1U] == old_data_id);
+  
+  //introduce the new value
+  out_packet[GATEWAY_ID_LEN + 2U] = (out_packet[GATEWAY_ID_LEN + 2U] + 1 ) % 32;
+
+  return 0;
+}
+
 //Sends a packet through LoRa. Blocking. Returns 0 if successful, 1 if error
 uint8 sendPacket(uint8* packet, uint16 packet_len)
 {

--- a/lib/LoRaPrivate/LoRaPrivate.h
+++ b/lib/LoRaPrivate/LoRaPrivate.h
@@ -6,6 +6,7 @@
 
 uint8 LoRaConfig(void);
 bool isChannelBusy(void);
+uint8 prepareNextPacket(void);
 uint8 sendPacket(uint8* packet, uint16 packet_len);
 uint8 awaitAck(void);
 //uint8 replyAck(void);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,13 +37,7 @@ void setup() {
   }
   else
   {
-    uint8 old_data_id = out_packet[3];
-    do
-    {
-      out_packet[3] = (uint8)random(0xFF);
-    }while(out_packet[3] == old_data_id);
-    
-    out_packet[4] = (out_packet[4] + 1 ) % 32;
+    (void)prepareNextPacket();
     Serial.println("Sleeping for 2 minutes");
     esp_deep_sleep(120*1000000); 
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,8 @@ void setup() {
 
   if(sendPacket(out_packet, sizeof(out_packet)))
   {
-    SwReset(10);
+    Serial.println("Failed to send packet. Retrying in a few seconds");
+    esp_deep_sleep(random(100,140)*100000);
   }
   
   if(awaitAck())
@@ -36,7 +37,13 @@ void setup() {
   }
   else
   {
-    out_packet[3] = (out_packet[3] + 1 ) % 32;
+    uint8 old_data_id = out_packet[3];
+    do
+    {
+      out_packet[3] = (uint8)random(0xFF);
+    }while(out_packet[3] == old_data_id);
+    
+    out_packet[4] = (out_packet[4] + 1 ) % 32;
     Serial.println("Sleeping for 2 minutes");
     esp_deep_sleep(120*1000000); 
   }


### PR DESCRIPTION
If emitter receives ack, a new random data id (did) will be generated and sent with the new data. The new did can be any number from 0 to 254, except the previous did.
If emitter fails to receive ack, the data and did will not change.
did of 255 is reserved.
This way, the next time the data is transmitted:

If the message did not reach the gateway the first time, it will this time. The did will tell the gateway that the data is new for it.
If the message did reach to gateway, but the ack replay failed the first time, on the second time the gateway can detect a duplicated value by comparing the received did with the previous one. If they coincide, the data is duplicated and sould not be uploaded to the data base.