### PR TITLE
Update time periodically via LoRa

### DIFF
--- a/lib/LoRaPrivate/LoRaCfg.h
+++ b/lib/LoRaPrivate/LoRaCfg.h
@@ -21,7 +21,7 @@
 #define GATEWAY_ID_LEN      2U                      //Number of bytes that compose the gateway ID
 #define CLDTIME_MSG_ID      0xFF                    //ID that defines a time update message
 
-#define OUT_BUFFER_SIZE     GATEWAY_ID_LEN + 3U     //Bytes per packet that will be sent
+#define OUT_BUFFER_SIZE     GATEWAY_ID_LEN + 4U     //Bytes per packet that will be sent
 #define IN_BUFFER_SIZE      255U                    //Maximum number of bytes per input packet
 
 #define ACK_TIMEOUT         5000U                   //Acknowledgment timeout (ms)

--- a/lib/LoRaPrivate/LoRaPrivate.cpp
+++ b/lib/LoRaPrivate/LoRaPrivate.cpp
@@ -80,14 +80,12 @@ uint8 prepareNextPacket(void)
   }while(out_packet[GATEWAY_ID_LEN + 1U] == old_data_id);
   
   //introduce the new value
-  //out_packet[GATEWAY_ID_LEN + 2U] = (out_packet[GATEWAY_ID_LEN + 2U] + 1 ) % 32;
-
   uint16 an_val = analogRead(13);
   uint8* p_an_val = (uint8*)(&an_val);
   out_packet[GATEWAY_ID_LEN + 2U] = p_an_val[0];
   out_packet[GATEWAY_ID_LEN + 3U] = p_an_val[1];
 
-  Serial.print("Sending next: ");
+  Serial.print("Read new value: ");
   Serial.println(an_val);
   
   return 0;

--- a/lib/LoRaPrivate/LoRaPrivate.cpp
+++ b/lib/LoRaPrivate/LoRaPrivate.cpp
@@ -6,7 +6,7 @@
 #include <LoRa.h>
 #include <customUtilities.h>
 
-RTC_DATA_ATTR uint8 out_packet [OUT_BUFFER_SIZE] = {(GATEWAY_ID & 0xFF00) >> 8, GATEWAY_ID & 0x00FF, EMITTER_ID, 69, 0}; //Final items: data id, data
+RTC_DATA_ATTR uint8 out_packet [OUT_BUFFER_SIZE] = {(GATEWAY_ID & 0xFF00) >> 8, GATEWAY_ID & 0x00FF, EMITTER_ID, 69, 0, 0}; //Final items: data id, data0, data1
 volatile uint8 in_packet [IN_BUFFER_SIZE];
 
 volatile bool Cad_isr_responded = false;
@@ -80,8 +80,16 @@ uint8 prepareNextPacket(void)
   }while(out_packet[GATEWAY_ID_LEN + 1U] == old_data_id);
   
   //introduce the new value
-  out_packet[GATEWAY_ID_LEN + 2U] = (out_packet[GATEWAY_ID_LEN + 2U] + 1 ) % 32;
+  //out_packet[GATEWAY_ID_LEN + 2U] = (out_packet[GATEWAY_ID_LEN + 2U] + 1 ) % 32;
 
+  uint16 an_val = analogRead(13);
+  uint8* p_an_val = (uint8*)(&an_val);
+  out_packet[GATEWAY_ID_LEN + 2U] = p_an_val[0];
+  out_packet[GATEWAY_ID_LEN + 3U] = p_an_val[1];
+
+  Serial.print("Sending next: ");
+  Serial.println(an_val);
+  
   return 0;
 }
 

--- a/lib/timePrivate/timeCfg.h
+++ b/lib/timePrivate/timeCfg.h
@@ -6,5 +6,6 @@
 #define TZ_INFO "CET-1CEST,M3.5.0,M10.5.0/3"
 
 #define TCUPD_TIMEOUT 1000      //Time configuration update timeout (ms) 
+#define TUPD_PERIOD 10800U       //Period between time updates via WiFi (s)
 
 #endif // timeCfg_H

--- a/lib/timePrivate/timePrivate.cpp
+++ b/lib/timePrivate/timePrivate.cpp
@@ -7,11 +7,11 @@
 #include <esp_sleep.h>
 
 RTC_DATA_ATTR bool time_configured = false;
-RTC_DATA_ATTR time_t last_updated;
+RTC_DATA_ATTR time_t last_updated = 0;
 
 //On the first run, asks the gateway for the current calendar time via LoRa, and then updates the emitter clock internally.
 //After the first run, updates timezone info and shows the time.
-//Time can be reconigured after a wakeup by setting time_configured variable to false before going to sleep.
+//Time can be reconfigured after a wakeup by setting time_configured variable to false before going to sleep.
 //Returns 0 if successful, 1 if emitter could not ask for calendar time, 2 if gateway did not respond to the petition, 3 if time config API failed internally.
 uint8 timeConfigLoRa(void)
 {

--- a/lib/timePrivate/timePrivate.h
+++ b/lib/timePrivate/timePrivate.h
@@ -4,6 +4,7 @@
 #include <platformTypes.h>
 
 uint8 timeConfigLoRa(void);
+uint8 checkTimeUpdate(void);
 void sleepFor(uint16 seconds, uint16 minutes = 0U, uint16 hours = 0U, uint16 days = 0U);
 uint8 sleepUntil(int year, int month, int day, int hour, int minute, int second);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,8 @@
 #include <customUtilities.h>
 #include <timePrivate.h>
 
+RTC_DATA_ATTR bool sent_OK = true;
+
 void setup() {
  
   Serial.begin(115200);
@@ -17,34 +19,48 @@ void setup() {
   }
   delay(1000);
 
+  (void)checkTimeUpdate();
+
   if(timeConfigLoRa())
   {
     Serial.println("Retrying in a few seconds");
     esp_deep_sleep(random(100,140)*100000);
   }
 
+  if(sent_OK)
+  {
+    (void)prepareNextPacket();
+  }
+
   //Retry in a few seconds if channel is busy
   if(isChannelBusy())
   {
+    sent_OK = false;
     Serial.println("Channel is busy. Retrying in a few seconds");
     esp_deep_sleep(random(100,140)*100000);
   }
 
   if(sendPacket(out_packet, sizeof(out_packet)))
   {
+    sent_OK = false;
     Serial.println("Failed to send packet. Retrying in a few seconds");
     esp_deep_sleep(random(100,140)*100000);
   }
   
   if(awaitAck())
   {
+    sent_OK = false;
     Serial.println("Acknowledgement not received. Retrying in a few seconds");
     esp_deep_sleep(random(100,140)*100000);
   }
   else
   {
-    (void)prepareNextPacket();
-    (void)checkTimeUpdate();
+    sent_OK = true;
+
+    pinMode(2, OUTPUT);
+    digitalWrite(2, HIGH);
+    delay(1000);
+    digitalWrite(2, LOW);
 
     struct tm time_info;
 
@@ -52,18 +68,14 @@ void setup() {
     {
       (void)sleepFor(0, 5);
     }
-    if(time_info.tm_hour == 23)
+    if(time_info.tm_hour == 8)
     {
-      (void)sleepUntil(time_info.tm_year + 1900, time_info.tm_mon + 1, time_info.tm_mday + 1, 8, 0, 0);
+      (void)sleepUntil(time_info.tm_year + 1900, time_info.tm_mon + 1, time_info.tm_mday, 10, 0, 0); //do not send from 8 AM to 10 AM.
     }
     else
     {
-      (void)sleepFor(30);
+      (void)sleepFor(0, 5);
     }
-
-
-    
-    
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,26 @@ void setup() {
   else
   {
     (void)prepareNextPacket();
-    sleepFor(30);
+    (void)checkTimeUpdate();
+
+    struct tm time_info;
+
+    if(!getLocalTime(&time_info))
+    {
+      (void)sleepFor(0, 5);
+    }
+    if(time_info.tm_hour == 23)
+    {
+      (void)sleepUntil(time_info.tm_year + 1900, time_info.tm_mon + 1, time_info.tm_mday + 1, 8, 0, 0);
+    }
+    else
+    {
+      (void)sleepFor(30);
+    }
+
+
+    
+    
   }
 }
 


### PR DESCRIPTION
It has been detected that the ESP32 ticks a bit faster than it should be: For every hour that passes, the MCU's RTC has counted 1 hour and 20 seconds. A new function in timePrivate.h with name checkTimeUpdate(void) has been implemented. It reads the time of last clock update from WiFi, and gets the current RTC time. If the difference is greater than TUPD_PERIOD (in seconds), then the already existing function timeConfigLoRa() is called. This function is called from main after every wakeup.

This means that the RTC will be updated every TUPD_PERIOD (in seconds). This is a #define set in timeCfg.h. For the gateway, this number is set to 1800 (30 minutes), so as to be fairly updated (maximum of 10s error) since power consumption is not a problem. For the emitter, it is set to 10800 (3 hours), because power consumption IS an issue. Three hours is roughly the time that it would take for the MCU to be off by 1 minute.

Also, the prepeareNextPacket() function prepares OUT_BUFFER for sending an analog pin reading, so it occupies to bytes of information now (ESP32 incorporates a 12-bit ADC). All numbers around it have been modified to suit this reality. Counters are no longer sent since the reliability due to code issues has been tested enough.