### PR TITLE
Added Crc enable in LoRaConfig()

### DIFF
--- a/lib/LoRaPrivate/LoRaPrivate.cpp
+++ b/lib/LoRaPrivate/LoRaPrivate.cpp
@@ -34,6 +34,7 @@ uint8 LoRaConfig(void)
   //LoRa.setPreambleLength(PREAM_LEN);
   //LoRa.enableInvertIQ();
   //LoRa.setSyncWord(SYNC_WORD);
+  LoRa.enableCrc();
 
   LoRa.onCadDone(onCadDone); //call onCadDone ISR when channel activity detection has finished
   //LoRa.onTxDone(onTxDone); //call onTxDone ISR when packet has been fully sent


### PR DESCRIPTION
Just that. According to the LoRa.h documnetation by Sandeep Mistry, this line adds a crc bit to the LoRa packet. This value can be checked by the receiver, if it also has Crc enabled, to check the veracity of the values. This has not been tested.