### PR TITLE
each bin has its own start and end schedule now.

### DIFF
--- a/lib/collection/collectionCfg.cpp
+++ b/lib/collection/collectionCfg.cpp
@@ -1,0 +1,12 @@
+#include <collectionCfg.h>
+
+ uint16 bins[][6U] = {       /* COLLECTION SCHEDULE  */
+    /*BIN ID,   BIN CLUSTER, START  HH,MM , END HH,MM*/
+    {0      ,   0          ,        20,30 ,     21,00 },
+    {1      ,   0          ,        20,30 ,     21,00 },
+    {2      ,   0          ,        20,30 ,     21,00 },
+    {3      ,   1          ,        20,45 ,     21,15 },
+    {4      ,   1          ,        20,45 ,     21,15 },
+    {5      ,   2          ,        21,00 ,     21,30 },
+    {6      ,   3          ,        21,15 ,     21,45 }
+};

--- a/lib/collection/collectionCfg.h
+++ b/lib/collection/collectionCfg.h
@@ -1,10 +1,12 @@
 #ifndef collectionCfg_H
 #define collectionCfg_H
 
-#define COLLECTION_START    "20:30:00"  //Start time of garbage collection (hh:mm:ss)
-#define COLLECTION_END      "23:15:00"  //End time of garbage collection (hh:mm:ss)
+#include <platformTypes.h>
 
 #define COLLECTION_DAYS     "MTWRF"     //Place the collection days: sun(D)ay, (M)onday, (T)uesday, (W)ednesday, thu(R)sday, (F)riday, (S)aturday
+
+#define TOTAL_BINS      7U
+extern uint16 bins[TOTAL_BINS][6U];
 
 #define BIN_HEIGHT    150U        //Height of garbage container [cm]
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,8 +7,8 @@
 #include <collection.h>
 #include <AJ-SR04M_Drv.h>
 
-#define MIN_RETRY_DELAY 10000U //ms
-#define MAX_RETRY_DELAY 15000U //ms
+#define MIN_RETRY_DELAY 5000U //ms
+#define MAX_RETRY_DELAY 10000U //ms
 
 void setup() {
  
@@ -18,7 +18,7 @@ void setup() {
 
   if(scheduleConfig())
   {
-    Serial.println("Schedule has bad parsing. Check it in lib/collection/collectionCfg.h");
+    Serial.println("Schedule has something wrong. Check it in lib/collection/collectionCfg.cpp and .h");
     (void)sleepFor(0, 0, 0, 0xFFFF);
   }
 


### PR DESCRIPTION
New file collectionCfg.cpp with a bins table. Each bin has a start and end time (hh,mm).

New function findBin() to get the row of the bins table that contains info of the specific bin_id.

new function tableTimeToSimpleTime() to read the time of bins table and tranfer it to a simple_time struct.

stringTimeTo SimpleTime() is now deprecated.